### PR TITLE
Fix posting data in request

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -223,6 +223,10 @@ export default class {
 			Accept: 'application/json'
 		}
 
+		if ( method !== 'GET' && method !== 'HEAD' && data ) {
+			headers['Content-Type'] = 'application/x-www-form-urlencoded';
+		}
+
 		/**
 		 * Only attach the oauth headers if we have a request token
 		 */


### PR DESCRIPTION
Right now, using the convenience methods (`.get()`, `.post()`, etc) sends `Content-Type: text/plain`, which means that the data is never actually parsed out. :(